### PR TITLE
feat: add WallpaperX image-to-BMP converter with global upload progress

### DIFF
--- a/SendToX4/Models/ActivityEvent.swift
+++ b/SendToX4/Models/ActivityEvent.swift
@@ -6,7 +6,7 @@ import SwiftData
 /// Broad category of activity — allows filtering and future expansion.
 enum ActivityCategory: String, Codable, CaseIterable {
     case fileManager
-    // Future: case convert, case wallpaper, etc.
+    case wallpaper
 }
 
 /// Specific action performed within a category.
@@ -17,7 +17,7 @@ enum ActivityAction: String, Codable {
     case moveFile
     case deleteFile
     case deleteFolder
-    // Future: case renameFile, case wallpaperUpload, etc.
+    case wallpaperUpload
 }
 
 /// Outcome of the activity.
@@ -80,22 +80,24 @@ final class ActivityEvent {
     /// SF Symbol name for this action type.
     var iconName: String {
         switch action {
-        case .upload:       return "arrow.up.doc.fill"
-        case .createFolder: return "folder.badge.plus"
-        case .moveFile:     return "arrow.right.doc.on.clipboard"
-        case .deleteFile:   return "trash.fill"
-        case .deleteFolder: return "trash.fill"
+        case .upload:          return "arrow.up.doc.fill"
+        case .createFolder:    return "folder.badge.plus"
+        case .moveFile:        return "arrow.right.doc.on.clipboard"
+        case .deleteFile:      return "trash.fill"
+        case .deleteFolder:    return "trash.fill"
+        case .wallpaperUpload: return "photo.artframe"
         }
     }
 
     /// Human-readable action label.
     var actionLabel: String {
         switch action {
-        case .upload:       return "File Uploaded"
-        case .createFolder: return "Folder Created"
-        case .moveFile:     return "File Moved"
-        case .deleteFile:   return "File Deleted"
-        case .deleteFolder: return "Folder Deleted"
+        case .upload:          return "File Uploaded"
+        case .createFolder:    return "Folder Created"
+        case .moveFile:        return "File Moved"
+        case .deleteFile:      return "File Deleted"
+        case .deleteFolder:    return "Folder Deleted"
+        case .wallpaperUpload: return "Wallpaper Sent"
         }
     }
 }

--- a/SendToX4/Models/DeviceSettings.swift
+++ b/SendToX4/Models/DeviceSettings.swift
@@ -21,7 +21,6 @@ enum FirmwareType: String, Codable, CaseIterable {
 final class DeviceSettings {
     var firmwareTypeRaw: String
     var customIP: String
-    var showWallpaperX: Bool
     var showFileManager: Bool
 
     // MARK: - Per-Feature Destination Folders
@@ -50,14 +49,12 @@ final class DeviceSettings {
         customIP: String = "",
         convertFolder: String = "content",
         wallpaperFolder: String = "sleep",
-        showWallpaperX: Bool = false,
         showFileManager: Bool = false
     ) {
         self.firmwareTypeRaw = firmwareType.rawValue
         self.customIP = customIP
         self.convertFolder = convertFolder
         self.wallpaperFolder = wallpaperFolder
-        self.showWallpaperX = showWallpaperX
         self.showFileManager = showFileManager
     }
 }

--- a/SendToX4/Models/DeviceSpecification.swift
+++ b/SendToX4/Models/DeviceSpecification.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+/// Data-driven device profile for wallpaper conversion.
+///
+/// Each specification describes a target device's screen resolution.
+/// New devices are added by creating a new static property and including
+/// it in the ``all`` array — no code changes elsewhere required.
+nonisolated struct DeviceSpecification: Identifiable, Sendable {
+    let id: String
+    let name: String
+    let resolution: CGSize
+
+    /// Width-to-height ratio of the device screen.
+    var aspectRatio: CGFloat {
+        resolution.width / resolution.height
+    }
+}
+
+// MARK: - Equatable & Hashable (CGSize is not Hashable)
+
+extension DeviceSpecification: Equatable {
+    static func == (lhs: DeviceSpecification, rhs: DeviceSpecification) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+extension DeviceSpecification: Hashable {
+    func hash(into hasher: inout Hasher) {
+        hasher.combine(id)
+    }
+
+    // MARK: - Known Devices
+
+    /// Xtreink X4 e-reader (480 x 800 e-ink display).
+    static let x4 = DeviceSpecification(
+        id: "x4",
+        name: "Xtreink X4",
+        resolution: CGSize(width: 480, height: 800)
+    )
+
+    /// All known device profiles.
+    static let all: [DeviceSpecification] = [.x4]
+}

--- a/SendToX4/Models/WallpaperSettings.swift
+++ b/SendToX4/Models/WallpaperSettings.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+// MARK: - Fit Mode
+
+/// How the source image fills the target device canvas.
+enum WallpaperFitMode: String, CaseIterable, Sendable {
+    case fill    = "Fill"
+    case fit     = "Fit"
+    case stretch = "Stretch"
+
+    /// SF Symbol for display in segmented controls.
+    var iconName: String {
+        switch self {
+        case .fill:    return "arrow.up.left.and.arrow.down.right"
+        case .fit:     return "arrow.down.right.and.arrow.up.left"
+        case .stretch: return "arrow.left.and.right"
+        }
+    }
+}
+
+// MARK: - 9-Point Alignment
+
+/// Alignment anchor within the target canvas.
+enum WallpaperAlignment: String, CaseIterable, Sendable {
+    case topLeft      = "top-left"
+    case topCenter    = "top-center"
+    case topRight     = "top-right"
+    case centerLeft   = "center-left"
+    case centerCenter = "center-center"
+    case centerRight  = "center-right"
+    case bottomLeft   = "bottom-left"
+    case bottomCenter = "bottom-center"
+    case bottomRight  = "bottom-right"
+
+    /// Grid position (column 0-2, row 0-2) for the alignment grid UI.
+    var gridPosition: (column: Int, row: Int) {
+        switch self {
+        case .topLeft:      return (0, 0)
+        case .topCenter:    return (1, 0)
+        case .topRight:     return (2, 0)
+        case .centerLeft:   return (0, 1)
+        case .centerCenter: return (1, 1)
+        case .centerRight:  return (2, 1)
+        case .bottomLeft:   return (0, 2)
+        case .bottomCenter: return (1, 2)
+        case .bottomRight:  return (2, 2)
+        }
+    }
+
+    /// Horizontal component of the alignment.
+    var horizontal: HorizontalComponent {
+        switch self {
+        case .topLeft, .centerLeft, .bottomLeft:       return .left
+        case .topCenter, .centerCenter, .bottomCenter: return .center
+        case .topRight, .centerRight, .bottomRight:    return .right
+        }
+    }
+
+    /// Vertical component of the alignment.
+    var vertical: VerticalComponent {
+        switch self {
+        case .topLeft, .topCenter, .topRight:          return .top
+        case .centerLeft, .centerCenter, .centerRight: return .center
+        case .bottomLeft, .bottomCenter, .bottomRight: return .bottom
+        }
+    }
+
+    enum HorizontalComponent { case left, center, right }
+    enum VerticalComponent { case top, center, bottom }
+}
+
+// MARK: - Rotation
+
+/// Image rotation in 90-degree increments.
+enum WallpaperRotation: Int, CaseIterable, Sendable {
+    case none   = 0
+    case cw90   = 90
+    case cw180  = 180
+    case cw270  = 270
+
+    /// Rotate 90 degrees clockwise.
+    var rotatedClockwise: WallpaperRotation {
+        WallpaperRotation(rawValue: (rawValue + 90) % 360) ?? .none
+    }
+
+    /// Rotate 90 degrees counter-clockwise.
+    var rotatedCounterClockwise: WallpaperRotation {
+        WallpaperRotation(rawValue: (rawValue - 90 + 360) % 360) ?? .none
+    }
+
+    /// Whether width and height are swapped (90 or 270 degrees).
+    var swapsDimensions: Bool {
+        self == .cw90 || self == .cw270
+    }
+
+    /// Rotation angle in radians for Core Graphics transforms.
+    var radians: CGFloat {
+        CGFloat(rawValue) * .pi / 180.0
+    }
+}
+
+// MARK: - Color Depth
+
+/// BMP output bit depth.
+enum BMPColorDepth: Int, CaseIterable, Sendable {
+    case depth24 = 24
+    case depth8  = 8
+    case depth4  = 4
+    case depth1  = 1
+
+    /// Human-readable label.
+    var label: String {
+        switch self {
+        case .depth24: return "24-bit"
+        case .depth8:  return "8-bit"
+        case .depth4:  return "4-bit"
+        case .depth1:  return "1-bit"
+        }
+    }
+
+    /// Whether this depth is recommended for the X4 device.
+    var isRecommended: Bool {
+        self == .depth24 || self == .depth8
+    }
+
+    /// Warning text for non-recommended depths.
+    var warningText: String? {
+        isRecommended ? nil : "Not recommended for use with X4"
+    }
+}
+
+// MARK: - Wallpaper Settings
+
+/// All user-configurable settings for wallpaper conversion.
+///
+/// This is ephemeral state owned by the ViewModel — not persisted via SwiftData.
+/// Defaults match the reference converter's recommended settings for e-ink displays.
+struct WallpaperSettings: Sendable {
+    var fitMode: WallpaperFitMode = .fill
+    var alignment: WallpaperAlignment = .centerCenter
+    var rotation: WallpaperRotation = .none
+    var colorDepth: BMPColorDepth = .depth24
+    var grayscale: Bool = true
+    var invert: Bool = false
+}

--- a/SendToX4/Services/BMPEncoder.swift
+++ b/SendToX4/Services/BMPEncoder.swift
@@ -1,0 +1,340 @@
+import CoreGraphics
+import Foundation
+
+/// Encodes a `CGImage` into Windows BMP format (BITMAPINFOHEADER, BI_RGB).
+///
+/// Faithfully implements the BMP specification used by the X4 wallpaper converter:
+/// - 14-byte file header + 40-byte DIB header (BITMAPINFOHEADER)
+/// - No compression (BI_RGB)
+/// - Bottom-up scanline order
+/// - 4-byte row alignment
+/// - BGR channel order for 24-bit; palette-indexed for 8/4/1-bit
+nonisolated struct BMPEncoder {
+
+    // MARK: - Public API
+
+    /// Encode a CGImage as BMP data at the specified color depth.
+    ///
+    /// - Parameters:
+    ///   - image: The source image (must have accessible pixel data).
+    ///   - depth: Target BMP bit depth (24, 8, 4, or 1).
+    /// - Returns: A `Data` object containing the complete BMP file.
+    static func encode(image: CGImage, depth: BMPColorDepth) -> Data {
+        let width = image.width
+        let height = image.height
+
+        // Extract RGBA pixel data from the CGImage
+        let pixels = extractPixels(from: image, width: width, height: height)
+
+        // Build BMP components
+        let palette = buildPalette(for: depth)
+        let pixelData = encodePixelData(
+            pixels: pixels,
+            width: width,
+            height: height,
+            depth: depth
+        )
+
+        let paletteSize = palette.count
+        let headerSize = 14 + 40 // File header + DIB header
+        let pixelOffset = headerSize + paletteSize
+        let fileSize = pixelOffset + pixelData.count
+
+        var data = Data(capacity: fileSize)
+
+        // File Header (14 bytes)
+        data.appendBMPUInt16(0x4D42)           // "BM" magic (little-endian: 0x42='B', 0x4D='M')
+        data.appendBMPUInt32(UInt32(fileSize))  // Total file size
+        data.appendBMPUInt16(0)                 // Reserved
+        data.appendBMPUInt16(0)                 // Reserved
+        data.appendBMPUInt32(UInt32(pixelOffset)) // Offset to pixel data
+
+        // DIB Header — BITMAPINFOHEADER (40 bytes)
+        data.appendBMPUInt32(40)               // DIB header size
+        data.appendBMPInt32(Int32(width))       // Width
+        data.appendBMPInt32(Int32(height))      // Height (positive = bottom-up)
+        data.appendBMPUInt16(1)                 // Color planes
+        data.appendBMPUInt16(UInt16(depth.rawValue)) // Bits per pixel
+        data.appendBMPUInt32(0)                 // Compression (BI_RGB)
+        data.appendBMPUInt32(UInt32(pixelData.count)) // Pixel data size
+        data.appendBMPUInt32(2835)              // Horizontal resolution (~72 DPI)
+        data.appendBMPUInt32(2835)              // Vertical resolution (~72 DPI)
+        let colorCount: UInt32 = depth == .depth24 ? 0 : UInt32(1 << depth.rawValue)
+        data.appendBMPUInt32(colorCount)        // Colors in palette
+        data.appendBMPUInt32(0)                 // Important colors (0 = all)
+
+        // Color palette
+        data.append(palette)
+
+        // Pixel data
+        data.append(pixelData)
+
+        return data
+    }
+
+    // MARK: - Pixel Extraction
+
+    /// Extract raw RGBA pixel data from a CGImage.
+    private static func extractPixels(
+        from image: CGImage,
+        width: Int,
+        height: Int
+    ) -> [UInt8] {
+        let bytesPerPixel = 4
+        let bytesPerRow = width * bytesPerPixel
+        let totalBytes = height * bytesPerRow
+
+        var pixelData = [UInt8](repeating: 0, count: totalBytes)
+
+        guard let context = CGContext(
+            data: &pixelData,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return pixelData
+        }
+
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+        return pixelData
+    }
+
+    // MARK: - Palette Generation
+
+    /// Build the color palette for the given depth.
+    private static func buildPalette(for depth: BMPColorDepth) -> Data {
+        switch depth {
+        case .depth24:
+            return Data() // No palette for 24-bit
+
+        case .depth8:
+            // 256-color palette: 3-3-2 RGB mapping
+            var palette = Data(capacity: 256 * 4)
+            for i in 0..<256 {
+                let r = UInt8(Double((i >> 5) & 0x07) * 255.0 / 7.0 + 0.5)
+                let g = UInt8(Double((i >> 2) & 0x07) * 255.0 / 7.0 + 0.5)
+                let b = UInt8(Double(i & 0x03) * 255.0 / 3.0 + 0.5)
+                palette.append(b)  // Blue
+                palette.append(g)  // Green
+                palette.append(r)  // Red
+                palette.append(0)  // Reserved
+            }
+            return palette
+
+        case .depth4:
+            // 16-level uniform grayscale palette
+            var palette = Data(capacity: 16 * 4)
+            for i in 0..<16 {
+                let gray = UInt8(Double(i) * 255.0 / 15.0 + 0.5)
+                palette.append(gray) // Blue
+                palette.append(gray) // Green
+                palette.append(gray) // Red
+                palette.append(0)    // Reserved
+            }
+            return palette
+
+        case .depth1:
+            // 2-color: black and white
+            var palette = Data(capacity: 2 * 4)
+            // Index 0: Black
+            palette.append(contentsOf: [0, 0, 0, 0])
+            // Index 1: White
+            palette.append(contentsOf: [255, 255, 255, 0])
+            return palette
+        }
+    }
+
+    // MARK: - Pixel Data Encoding
+
+    /// Encode pixel data in BMP bottom-up scanline format.
+    private static func encodePixelData(
+        pixels: [UInt8],
+        width: Int,
+        height: Int,
+        depth: BMPColorDepth
+    ) -> Data {
+        let rowSize = Self.rowSize(width: width, depth: depth)
+        var data = Data(capacity: rowSize * height)
+        let srcBytesPerRow = width * 4
+
+        // BMP stores rows bottom-up
+        for y in stride(from: height - 1, through: 0, by: -1) {
+            let rowStart = y * srcBytesPerRow
+
+            switch depth {
+            case .depth24:
+                encode24BitRow(
+                    pixels: pixels,
+                    rowStart: rowStart,
+                    width: width,
+                    rowSize: rowSize,
+                    into: &data
+                )
+
+            case .depth8:
+                encode8BitRow(
+                    pixels: pixels,
+                    rowStart: rowStart,
+                    width: width,
+                    rowSize: rowSize,
+                    into: &data
+                )
+
+            case .depth4:
+                encode4BitRow(
+                    pixels: pixels,
+                    rowStart: rowStart,
+                    width: width,
+                    rowSize: rowSize,
+                    into: &data
+                )
+
+            case .depth1:
+                encode1BitRow(
+                    pixels: pixels,
+                    rowStart: rowStart,
+                    width: width,
+                    rowSize: rowSize,
+                    into: &data
+                )
+            }
+        }
+
+        return data
+    }
+
+    /// Padded row size in bytes (4-byte aligned).
+    private static func rowSize(width: Int, depth: BMPColorDepth) -> Int {
+        switch depth {
+        case .depth24:
+            return ((width * 3 + 3) / 4) * 4
+        case .depth8:
+            return ((width + 3) / 4) * 4
+        case .depth4:
+            return (((width + 1) / 2 + 3) / 4) * 4
+        case .depth1:
+            return (((width + 7) / 8 + 3) / 4) * 4
+        }
+    }
+
+    // MARK: - Per-Row Encoders
+
+    /// 24-bit: 3 bytes per pixel in BGR order.
+    private static func encode24BitRow(
+        pixels: [UInt8],
+        rowStart: Int,
+        width: Int,
+        rowSize: Int,
+        into data: inout Data
+    ) {
+        var row = Data(count: rowSize)
+        for x in 0..<width {
+            let srcIdx = rowStart + x * 4
+            let dstIdx = x * 3
+            row[dstIdx]     = pixels[srcIdx + 2] // B
+            row[dstIdx + 1] = pixels[srcIdx + 1] // G
+            row[dstIdx + 2] = pixels[srcIdx]     // R
+        }
+        data.append(row)
+    }
+
+    /// 8-bit: 1 byte palette index using 3-3-2 RGB mapping.
+    private static func encode8BitRow(
+        pixels: [UInt8],
+        rowStart: Int,
+        width: Int,
+        rowSize: Int,
+        into data: inout Data
+    ) {
+        var row = Data(count: rowSize)
+        for x in 0..<width {
+            let srcIdx = rowStart + x * 4
+            let r = pixels[srcIdx]
+            let g = pixels[srcIdx + 1]
+            let b = pixels[srcIdx + 2]
+            let index = ((r >> 5) << 5) | ((g >> 5) << 2) | (b >> 6)
+            row[x] = index
+        }
+        data.append(row)
+    }
+
+    /// 4-bit: 2 pixels per byte (high nibble first), grayscale palette.
+    private static func encode4BitRow(
+        pixels: [UInt8],
+        rowStart: Int,
+        width: Int,
+        rowSize: Int,
+        into data: inout Data
+    ) {
+        var row = Data(count: rowSize)
+        for x in 0..<width {
+            let srcIdx = rowStart + x * 4
+            let r = Double(pixels[srcIdx])
+            let g = Double(pixels[srcIdx + 1])
+            let b = Double(pixels[srcIdx + 2])
+            let gray = r * 0.299 + g * 0.587 + b * 0.114
+            let index = UInt8((gray / 255.0 * 15.0).rounded())
+
+            let byteIdx = x / 2
+            if x % 2 == 0 {
+                row[byteIdx] = index << 4 // High nibble
+            } else {
+                row[byteIdx] |= index     // Low nibble
+            }
+        }
+        data.append(row)
+    }
+
+    /// 1-bit: 8 pixels per byte (MSB first), threshold at 127.
+    private static func encode1BitRow(
+        pixels: [UInt8],
+        rowStart: Int,
+        width: Int,
+        rowSize: Int,
+        into data: inout Data
+    ) {
+        var row = Data(count: rowSize)
+        for x in 0..<width {
+            let srcIdx = rowStart + x * 4
+            let r = Double(pixels[srcIdx])
+            let g = Double(pixels[srcIdx + 1])
+            let b = Double(pixels[srcIdx + 2])
+            let gray = r * 0.299 + g * 0.587 + b * 0.114
+            let bit: UInt8 = gray > 127 ? 1 : 0
+
+            let byteIdx = x / 8
+            let bitPos = 7 - (x % 8) // MSB first
+            row[byteIdx] |= bit << bitPos
+        }
+        data.append(row)
+    }
+}
+
+// MARK: - Data Helpers for BMP Binary Writing
+
+private extension Data {
+    /// Append a 16-bit unsigned integer in little-endian byte order.
+    mutating func appendBMPUInt16(_ value: UInt16) {
+        var le = value.littleEndian
+        append(UnsafeBufferPointer(start: &le, count: 1))
+    }
+
+    /// Append a 32-bit unsigned integer in little-endian byte order.
+    mutating func appendBMPUInt32(_ value: UInt32) {
+        var le = value.littleEndian
+        append(UnsafeBufferPointer(start: &le, count: 1))
+    }
+
+    /// Append a 32-bit signed integer in little-endian byte order.
+    mutating func appendBMPInt32(_ value: Int32) {
+        var le = value.littleEndian
+        withUnsafePointer(to: &le) { ptr in
+            ptr.withMemoryRebound(to: UInt8.self, capacity: 4) { bytes in
+                append(bytes, count: 4)
+            }
+        }
+    }
+}

--- a/SendToX4/Services/WallpaperImageProcessor.swift
+++ b/SendToX4/Services/WallpaperImageProcessor.swift
@@ -1,0 +1,396 @@
+import CoreGraphics
+import Foundation
+
+/// Processes images for device wallpaper conversion using Core Graphics.
+///
+/// The pipeline matches the reference X4 wallpaper converter:
+/// 1. Apply rotation
+/// 2. Create target-sized canvas with background fill
+/// 3. Draw image using the selected fit mode and alignment
+/// 4. Apply grayscale conversion (BT.601 luminance)
+/// 5. Apply color inversion (if enabled)
+/// 6. Apply color depth quantization
+nonisolated struct WallpaperImageProcessor {
+
+    // MARK: - Public API
+
+    /// Process a source image with the given settings for the target device.
+    ///
+    /// - Parameters:
+    ///   - image: Original source CGImage.
+    ///   - settings: User-configured wallpaper settings.
+    ///   - device: Target device specification (resolution).
+    /// - Returns: Processed CGImage at the device's resolution, or `nil` on failure.
+    static func process(
+        image: CGImage,
+        settings: WallpaperSettings,
+        device: DeviceSpecification
+    ) -> CGImage? {
+        let targetWidth = Int(device.resolution.width)
+        let targetHeight = Int(device.resolution.height)
+
+        // Create the target-sized canvas
+        guard let context = createContext(width: targetWidth, height: targetHeight) else {
+            return nil
+        }
+
+        // Fill background (black)
+        context.setFillColor(CGColor(red: 0, green: 0, blue: 0, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: targetWidth, height: targetHeight))
+
+        // Calculate effective source dimensions after rotation
+        let sourceWidth = CGFloat(image.width)
+        let sourceHeight = CGFloat(image.height)
+        let effWidth: CGFloat
+        let effHeight: CGFloat
+
+        if settings.rotation.swapsDimensions {
+            effWidth = sourceHeight
+            effHeight = sourceWidth
+        } else {
+            effWidth = sourceWidth
+            effHeight = sourceHeight
+        }
+
+        // Calculate draw rect based on fit mode
+        let drawRect: CGRect
+        let sourceRect: CGRect
+
+        switch settings.fitMode {
+        case .stretch:
+            drawRect = CGRect(x: 0, y: 0, width: targetWidth, height: targetHeight)
+            sourceRect = CGRect(x: 0, y: 0, width: sourceWidth, height: sourceHeight)
+
+        case .fit:
+            let (rect, srcRect) = fitCalculation(
+                effectiveWidth: effWidth,
+                effectiveHeight: effHeight,
+                targetWidth: CGFloat(targetWidth),
+                targetHeight: CGFloat(targetHeight),
+                alignment: settings.alignment,
+                sourceWidth: sourceWidth,
+                sourceHeight: sourceHeight
+            )
+            drawRect = rect
+            sourceRect = srcRect
+
+        case .fill:
+            let (rect, srcRect) = fillCalculation(
+                effectiveWidth: effWidth,
+                effectiveHeight: effHeight,
+                targetWidth: CGFloat(targetWidth),
+                targetHeight: CGFloat(targetHeight),
+                alignment: settings.alignment,
+                sourceWidth: sourceWidth,
+                sourceHeight: sourceHeight,
+                rotation: settings.rotation
+            )
+            drawRect = rect
+            sourceRect = srcRect
+        }
+
+        // Draw the image with rotation
+        drawRotatedImage(
+            context: context,
+            image: image,
+            rotation: settings.rotation,
+            drawRect: drawRect,
+            sourceRect: sourceRect
+        )
+
+        // Get the rendered image for pixel manipulation
+        guard let rendered = context.makeImage() else { return nil }
+
+        // Apply pixel-level effects (grayscale, invert, depth quantization)
+        return applyEffects(
+            to: rendered,
+            width: targetWidth,
+            height: targetHeight,
+            settings: settings
+        )
+    }
+
+    // MARK: - Context Creation
+
+    /// Create a 32-bit RGBA CGContext.
+    private static func createContext(width: Int, height: Int) -> CGContext? {
+        CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: width * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        )
+    }
+
+    // MARK: - Fit Mode Calculations
+
+    /// Calculate draw rect for **fit** mode (image fully visible, letterboxed).
+    private static func fitCalculation(
+        effectiveWidth: CGFloat,
+        effectiveHeight: CGFloat,
+        targetWidth: CGFloat,
+        targetHeight: CGFloat,
+        alignment: WallpaperAlignment,
+        sourceWidth: CGFloat,
+        sourceHeight: CGFloat
+    ) -> (drawRect: CGRect, sourceRect: CGRect) {
+        let imgRatio = effectiveWidth / effectiveHeight
+        let canvasRatio = targetWidth / targetHeight
+
+        let drawWidth: CGFloat
+        let drawHeight: CGFloat
+
+        if imgRatio > canvasRatio {
+            // Image is wider — fit to width, letterbox top/bottom
+            drawWidth = targetWidth
+            drawHeight = targetWidth / imgRatio
+        } else {
+            // Image is taller — fit to height, pillarbox left/right
+            drawHeight = targetHeight
+            drawWidth = targetHeight * imgRatio
+        }
+
+        let offset = alignmentOffset(
+            drawWidth: drawWidth,
+            drawHeight: drawHeight,
+            canvasWidth: targetWidth,
+            canvasHeight: targetHeight,
+            alignment: alignment
+        )
+
+        let drawRect = CGRect(x: offset.x, y: offset.y, width: drawWidth, height: drawHeight)
+        let sourceRect = CGRect(x: 0, y: 0, width: sourceWidth, height: sourceHeight)
+
+        return (drawRect, sourceRect)
+    }
+
+    /// Calculate draw and source rects for **fill** mode (image covers canvas, excess cropped).
+    private static func fillCalculation(
+        effectiveWidth: CGFloat,
+        effectiveHeight: CGFloat,
+        targetWidth: CGFloat,
+        targetHeight: CGFloat,
+        alignment: WallpaperAlignment,
+        sourceWidth: CGFloat,
+        sourceHeight: CGFloat,
+        rotation: WallpaperRotation
+    ) -> (drawRect: CGRect, sourceRect: CGRect) {
+        let scaleFactor = max(targetWidth / effectiveWidth, targetHeight / effectiveHeight)
+
+        // How much of the effective (rotated) image we need
+        let effCropWidth = targetWidth / scaleFactor
+        let effCropHeight = targetHeight / scaleFactor
+
+        // Determine offset within effective space based on alignment
+        let excessX = effectiveWidth - effCropWidth
+        let excessY = effectiveHeight - effCropHeight
+
+        var cropX: CGFloat = 0
+        var cropY: CGFloat = 0
+
+        switch alignment.horizontal {
+        case .left:   cropX = 0
+        case .center: cropX = excessX / 2
+        case .right:  cropX = excessX
+        }
+
+        // CG origin is bottom-left: invert vertical crop so .top crops
+        // from the visual top (high-Y end in CG coordinates).
+        switch alignment.vertical {
+        case .top:    cropY = excessY
+        case .center: cropY = excessY / 2
+        case .bottom: cropY = 0
+        }
+
+        // Remap effective-space coordinates back to original image coordinates
+        let srcX: CGFloat
+        let srcY: CGFloat
+        let srcW: CGFloat
+        let srcH: CGFloat
+
+        if rotation.swapsDimensions {
+            srcX = cropY
+            srcY = cropX
+            srcW = effCropHeight
+            srcH = effCropWidth
+        } else {
+            srcX = cropX
+            srcY = cropY
+            srcW = effCropWidth
+            srcH = effCropHeight
+        }
+
+        let drawRect = CGRect(x: 0, y: 0, width: targetWidth, height: targetHeight)
+        let sourceRect = CGRect(x: srcX, y: srcY, width: srcW, height: srcH)
+
+        return (drawRect, sourceRect)
+    }
+
+    /// Compute the (x, y) offset for positioning an image within the canvas.
+    private static func alignmentOffset(
+        drawWidth: CGFloat,
+        drawHeight: CGFloat,
+        canvasWidth: CGFloat,
+        canvasHeight: CGFloat,
+        alignment: WallpaperAlignment
+    ) -> CGPoint {
+        let x: CGFloat
+        let y: CGFloat
+
+        switch alignment.horizontal {
+        case .left:   x = 0
+        case .center: x = (canvasWidth - drawWidth) / 2
+        case .right:  x = canvasWidth - drawWidth
+        }
+
+        // CG origin is bottom-left: Y=0 is visual bottom, Y=max is visual top.
+        // Invert so .top maps to the visual top of the canvas.
+        switch alignment.vertical {
+        case .top:    y = canvasHeight - drawHeight
+        case .center: y = (canvasHeight - drawHeight) / 2
+        case .bottom: y = 0
+        }
+
+        return CGPoint(x: x, y: y)
+    }
+
+    // MARK: - Rotated Drawing
+
+    /// Draw a CGImage with rotation applied.
+    ///
+    /// Core Graphics uses a bottom-left origin with Y pointing up,
+    /// so we translate to the draw center, rotate, and draw offset.
+    private static func drawRotatedImage(
+        context: CGContext,
+        image: CGImage,
+        rotation: WallpaperRotation,
+        drawRect: CGRect,
+        sourceRect: CGRect
+    ) {
+        guard let cropped = image.cropping(to: sourceRect) else { return }
+
+        context.saveGState()
+
+        // Move origin to center of the draw rect
+        let centerX = drawRect.midX
+        let centerY = drawRect.midY
+        context.translateBy(x: centerX, y: centerY)
+
+        // Apply rotation (negative because CG Y-axis is flipped vs. screen coords)
+        context.rotate(by: -rotation.radians)
+
+        // Calculate the rect to draw into (centered at origin)
+        let drawW: CGFloat
+        let drawH: CGFloat
+
+        if rotation.swapsDimensions {
+            drawW = drawRect.height
+            drawH = drawRect.width
+        } else {
+            drawW = drawRect.width
+            drawH = drawRect.height
+        }
+
+        let rect = CGRect(
+            x: -drawW / 2,
+            y: -drawH / 2,
+            width: drawW,
+            height: drawH
+        )
+        context.draw(cropped, in: rect)
+
+        context.restoreGState()
+    }
+
+    // MARK: - Pixel Effects
+
+    /// Apply grayscale, inversion, and depth quantization to the rendered image.
+    private static func applyEffects(
+        to image: CGImage,
+        width: Int,
+        height: Int,
+        settings: WallpaperSettings
+    ) -> CGImage? {
+        let needsEffects = settings.grayscale || settings.invert || settings.colorDepth != .depth24
+        guard needsEffects else { return image }
+
+        let bytesPerPixel = 4
+        let bytesPerRow = width * bytesPerPixel
+        let totalBytes = height * bytesPerRow
+
+        var pixels = [UInt8](repeating: 0, count: totalBytes)
+
+        guard let context = CGContext(
+            data: &pixels,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: bytesPerRow,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ) else {
+            return image
+        }
+
+        context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+        // Process each pixel
+        for i in stride(from: 0, to: totalBytes, by: bytesPerPixel) {
+            var r = Double(pixels[i])
+            var g = Double(pixels[i + 1])
+            var b = Double(pixels[i + 2])
+
+            // Grayscale (BT.601 luminance)
+            if settings.grayscale {
+                let gray = r * 0.299 + g * 0.587 + b * 0.114
+                r = gray
+                g = gray
+                b = gray
+            }
+
+            // Invert
+            if settings.invert {
+                r = 255 - r
+                g = 255 - g
+                b = 255 - b
+            }
+
+            // Color depth quantization
+            switch settings.colorDepth {
+            case .depth24:
+                break // No quantization
+
+            case .depth8:
+                if !(r == g && g == b) {
+                    // 3-3-2 quantization
+                    r = (r / 255.0 * 7.0).rounded() * (255.0 / 7.0)
+                    g = (g / 255.0 * 7.0).rounded() * (255.0 / 7.0)
+                    b = (b / 255.0 * 3.0).rounded() * (255.0 / 3.0)
+                }
+
+            case .depth4:
+                let gray = r * 0.299 + g * 0.587 + b * 0.114
+                let quantized = (gray / 255.0 * 15.0).rounded() * (255.0 / 15.0)
+                r = quantized
+                g = quantized
+                b = quantized
+
+            case .depth1:
+                let gray = r * 0.299 + g * 0.587 + b * 0.114
+                let bw: Double = gray > 127 ? 255 : 0
+                r = bw
+                g = bw
+                b = bw
+            }
+
+            pixels[i]     = UInt8(min(255, max(0, r)))
+            pixels[i + 1] = UInt8(min(255, max(0, g)))
+            pixels[i + 2] = UInt8(min(255, max(0, b)))
+        }
+
+        return context.makeImage()
+    }
+}

--- a/SendToX4/ViewModels/ConvertViewModel.swift
+++ b/SendToX4/ViewModels/ConvertViewModel.swift
@@ -48,6 +48,11 @@ final class ConvertViewModel {
             return
         }
 
+        guard !deviceVM.isUploading else {
+            lastError = "An upload is already in progress."
+            return
+        }
+
         isProcessing = true
         lastError = nil
         lastEPUBData = nil

--- a/SendToX4/ViewModels/WallpaperViewModel.swift
+++ b/SendToX4/ViewModels/WallpaperViewModel.swift
@@ -1,0 +1,309 @@
+import CoreGraphics
+import Foundation
+import PhotosUI
+import SwiftData
+import SwiftUI
+
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+/// Orchestrates the WallpaperX workflow: image loading, processing, preview, and export.
+@MainActor
+@Observable
+final class WallpaperViewModel {
+
+    // MARK: - Image State
+
+    /// The original source image loaded from the user's selection.
+    var sourceImage: CGImage?
+
+    /// The processed preview image reflecting current settings.
+    var processedPreview: CGImage?
+
+    /// The filename of the imported image (without extension).
+    var sourceFilename: String?
+
+    /// PhotosPicker selection binding.
+    var selectedPhotoItem: PhotosPickerItem? {
+        didSet {
+            if let item = selectedPhotoItem {
+                Task { await loadImage(from: item) }
+            }
+        }
+    }
+
+    // MARK: - Settings
+
+    /// User-configurable conversion settings.
+    var settings = WallpaperSettings() {
+        didSet { schedulePreviewUpdate() }
+    }
+
+    /// Target device specification.
+    var device = DeviceSpecification.x4
+
+    // MARK: - UI State
+
+    var isProcessing = false
+    var errorMessage: String?
+    var statusMessage: String?
+    var showFileImporter = false
+    var showShareSheet = false
+
+    /// The last generated BMP data (for sharing/saving).
+    var lastBMPData: Data?
+    var lastBMPFilename: String?
+
+    // MARK: - Preview Debounce
+
+    private var previewTask: Task<Void, Never>?
+
+    // MARK: - Image Loading
+
+    /// Load an image from a PhotosPicker item.
+    func loadImage(from item: PhotosPickerItem) async {
+        errorMessage = nil
+        statusMessage = nil
+
+        do {
+            guard let data = try await item.loadTransferable(type: Data.self) else {
+                errorMessage = "Could not load the selected image."
+                return
+            }
+            loadImageFromData(data, filename: "photo")
+        } catch {
+            errorMessage = "Failed to load image: \(error.localizedDescription)"
+        }
+    }
+
+    /// Load an image from a file URL (Files app importer).
+    func loadImage(from url: URL) {
+        errorMessage = nil
+        statusMessage = nil
+
+        guard url.startAccessingSecurityScopedResource() else {
+            errorMessage = "Cannot access the selected file."
+            return
+        }
+        defer { url.stopAccessingSecurityScopedResource() }
+
+        do {
+            let data = try Data(contentsOf: url)
+            let stem = url.deletingPathExtension().lastPathComponent
+            loadImageFromData(data, filename: stem)
+        } catch {
+            errorMessage = "Failed to read file: \(error.localizedDescription)"
+        }
+    }
+
+    /// Common image loading from raw data.
+    private func loadImageFromData(_ data: Data, filename: String) {
+        #if canImport(UIKit)
+        guard let uiImage = UIImage(data: data),
+              let cgImage = uiImage.cgImage else {
+            errorMessage = "Unsupported image format."
+            return
+        }
+        #elseif canImport(AppKit)
+        guard let nsImage = NSImage(data: data),
+              let cgImage = nsImage.cgImage(
+                forProposedRect: nil,
+                context: nil,
+                hints: nil
+              ) else {
+            errorMessage = "Unsupported image format."
+            return
+        }
+        #endif
+
+        sourceImage = cgImage
+        sourceFilename = filename
+        lastBMPData = nil
+        lastBMPFilename = nil
+        statusMessage = nil
+
+        // Reset settings for new image
+        settings = WallpaperSettings()
+
+        updatePreview()
+    }
+
+    // MARK: - Preview Generation
+
+    /// Schedule a debounced preview update (50ms delay to batch rapid changes).
+    private func schedulePreviewUpdate() {
+        previewTask?.cancel()
+        previewTask = Task {
+            try? await Task.sleep(for: .milliseconds(50))
+            guard !Task.isCancelled else { return }
+            updatePreview()
+        }
+    }
+
+    /// Regenerate the preview image from the source using current settings.
+    func updatePreview() {
+        guard let source = sourceImage else {
+            processedPreview = nil
+            return
+        }
+
+        let currentSettings = settings
+        let currentDevice = device
+
+        // Run processing off the main actor for large images
+        Task.detached(priority: .userInitiated) {
+            let result = WallpaperImageProcessor.process(
+                image: source,
+                settings: currentSettings,
+                device: currentDevice
+            )
+            await MainActor.run {
+                self.processedPreview = result
+            }
+        }
+    }
+
+    // MARK: - Conversion & Upload
+
+    /// Convert the image and upload to the connected device.
+    func convertAndSend(
+        deviceVM: DeviceViewModel,
+        settings deviceSettings: DeviceSettings,
+        modelContext: ModelContext
+    ) async {
+        guard let source = sourceImage else {
+            errorMessage = "No image loaded."
+            return
+        }
+
+        guard !deviceVM.isUploading else {
+            errorMessage = "An upload is already in progress."
+            return
+        }
+
+        isProcessing = true
+        errorMessage = nil
+        statusMessage = "Processing..."
+
+        do {
+            // Process the image
+            guard let processed = WallpaperImageProcessor.process(
+                image: source,
+                settings: settings,
+                device: device
+            ) else {
+                throw WallpaperError.processingFailed
+            }
+
+            // Encode to BMP
+            statusMessage = "Encoding BMP..."
+            let bmpData = BMPEncoder.encode(image: processed, depth: settings.colorDepth)
+            let filename = generateFilename()
+
+            lastBMPData = bmpData
+            lastBMPFilename = filename
+
+            // Upload to device if connected
+            if deviceVM.isConnected {
+                statusMessage = "Sending to X4..."
+                try await deviceVM.upload(
+                    data: bmpData,
+                    filename: filename,
+                    toFolder: deviceSettings.wallpaperFolder
+                )
+
+                // Log activity event
+                let event = ActivityEvent(
+                    category: .wallpaper,
+                    action: .wallpaperUpload,
+                    status: .success,
+                    detail: filename
+                )
+                modelContext.insert(event)
+
+                statusMessage = "Sent \(filename) to /\(deviceSettings.wallpaperFolder)/"
+            } else {
+                statusMessage = "Converted \(filename) — save or connect to send."
+            }
+        } catch {
+            errorMessage = error.localizedDescription
+
+            // Log failed activity if it was a device upload failure
+            if deviceVM.isConnected {
+                let event = ActivityEvent(
+                    category: .wallpaper,
+                    action: .wallpaperUpload,
+                    status: .failed,
+                    detail: generateFilename(),
+                    errorMessage: error.localizedDescription
+                )
+                modelContext.insert(event)
+            }
+        }
+
+        isProcessing = false
+    }
+
+    /// Generate BMP data for local export (without device upload).
+    func exportBMPData() -> Data? {
+        guard let source = sourceImage else { return nil }
+
+        guard let processed = WallpaperImageProcessor.process(
+            image: source,
+            settings: settings,
+            device: device
+        ) else { return nil }
+
+        let bmpData = BMPEncoder.encode(image: processed, depth: settings.colorDepth)
+        let filename = generateFilename()
+
+        lastBMPData = bmpData
+        lastBMPFilename = filename
+
+        return bmpData
+    }
+
+    // MARK: - Clear
+
+    /// Remove the current image and reset state.
+    func clearImage() {
+        sourceImage = nil
+        processedPreview = nil
+        sourceFilename = nil
+        lastBMPData = nil
+        lastBMPFilename = nil
+        errorMessage = nil
+        statusMessage = nil
+        selectedPhotoItem = nil
+        settings = WallpaperSettings()
+    }
+
+    // MARK: - Helpers
+
+    /// Generate a unique BMP filename from the source filename + timestamp.
+    /// Prevents overwriting when sending multiple wallpapers.
+    private func generateFilename() -> String {
+        let stem = sourceFilename ?? "wallpaper"
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyyMMdd-HHmmss"
+        let timestamp = formatter.string(from: Date())
+        return "\(stem)-\(timestamp).bmp"
+    }
+}
+
+// MARK: - Errors
+
+enum WallpaperError: LocalizedError {
+    case processingFailed
+    case noImage
+
+    var errorDescription: String? {
+        switch self {
+        case .processingFailed: return "Image processing failed."
+        case .noImage: return "No image loaded."
+        }
+    }
+}

--- a/SendToX4/Views/DeviceConnectionAccessory.swift
+++ b/SendToX4/Views/DeviceConnectionAccessory.swift
@@ -57,7 +57,7 @@ struct DeviceConnectionAccessory: View {
 
     @ViewBuilder
     private var primaryLine: some View {
-        if isUploading, let filename = convertVM.lastFilename {
+        if isUploading, let filename = deviceVM.uploadFilename {
             Text("Sending \(uploadDisplayName(filename))... \(Int(deviceVM.uploadProgress * 100))%")
                 .font(.subheadline.weight(.semibold))
                 .lineLimit(1)
@@ -69,7 +69,10 @@ struct DeviceConnectionAccessory: View {
     }
 
     private func uploadDisplayName(_ filename: String) -> String {
-        filename.replacingOccurrences(of: ".epub", with: "").truncated(to: 24)
+        let name = filename
+            .replacingOccurrences(of: ".epub", with: "")
+            .replacingOccurrences(of: ".bmp", with: "")
+        return name.truncated(to: 24)
     }
 
     @ViewBuilder
@@ -132,8 +135,7 @@ struct DeviceConnectionAccessory: View {
     // MARK: - Helpers
 
     private var isUploading: Bool {
-        convertVM.isProcessing
-            && convertVM.currentPhase == .sending
+        deviceVM.isUploading
             && deviceVM.uploadProgress > 0
             && deviceVM.uploadProgress < 1.0
     }

--- a/SendToX4/Views/SettingsSheet.swift
+++ b/SendToX4/Views/SettingsSheet.swift
@@ -107,16 +107,6 @@ struct SettingsSheet: View {
                     .disabled(isTesting)
                 }
 
-                // MARK: - Experimental Section
-
-                Section {
-                    Toggle("WallpaperX", isOn: $settings.showWallpaperX)
-                } header: {
-                    Text("Experimental")
-                } footer: {
-                    Text("Enable experimental features still in development. WallpaperX allows custom wallpapers on the X4.")
-                }
-
                 // MARK: - About Section
 
                 Section {

--- a/SendToX4/Views/WallpaperXView.swift
+++ b/SendToX4/Views/WallpaperXView.swift
@@ -1,19 +1,984 @@
+import PhotosUI
+import SwiftData
 import SwiftUI
 
-/// Placeholder view for the experimental WallpaperX feature.
+// MARK: - WallpaperXView
+
+/// WallpaperX — convert images to BMP format for the X4 e-reader.
+///
+/// Layout:
+/// - **iOS**: Preview fills the screen. Quick controls (rotation) live in the
+///   `tabViewBottomAccessory` (set in MainView). Full settings open via a system
+///   `.sheet()` with presentation detents — smooth 120fps, no custom gestures.
+/// - **macOS**: Inline scroll layout with settings below the preview.
 struct WallpaperXView: View {
+    @Environment(\.modelContext) private var modelContext
+    @Bindable var wallpaperVM: WallpaperViewModel
     var deviceVM: DeviceViewModel
     var settings: DeviceSettings
 
+    @State private var showDevicePopover = false
+    @State private var showAppSettings = false
+
     var body: some View {
         NavigationStack {
-            ContentUnavailableView {
-                Label("WallpaperX", systemImage: "photo.artframe")
-            } description: {
-                Text("Coming soon — custom wallpapers for your X4.")
+            #if os(iOS)
+            iOSLayout
+            #else
+            macOSLayout
+            #endif
+        }
+    }
+
+    // MARK: - iOS Layout
+
+    #if os(iOS)
+    private var iOSLayout: some View {
+        VStack(spacing: 0) {
+            previewArea
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            statusBar
+        }
+        .navigationTitle("WallpaperX")
+        .toolbar { wallpaperToolbar }
+        .fileImporter(
+            isPresented: $wallpaperVM.showFileImporter,
+            allowedContentTypes: [.image],
+            allowsMultipleSelection: false
+        ) { handleFileImport($0) }
+        .sheet(isPresented: $wallpaperVM.showShareSheet) {
+            if let data = wallpaperVM.lastBMPData,
+               let filename = wallpaperVM.lastBMPFilename {
+                WallpaperShareSheetView(bmpData: data, filename: filename)
             }
-            .navigationTitle("WallpaperX")
-            .settingsToolbar(deviceVM: deviceVM, settings: settings)
+        }
+        .sheet(isPresented: $showAppSettings) {
+            SettingsSheet(deviceVM: deviceVM, settings: settings)
+        }
+    }
+    #endif
+
+    // MARK: - macOS Layout
+
+    #if os(macOS)
+    private var macOSLayout: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                devicePreviewCard
+                imageSourceButtons
+
+                if wallpaperVM.sourceImage != nil {
+                    settingsControls
+                        .padding(20)
+                        .glassEffect(.regular, in: .rect(cornerRadius: 12))
+                    statusDisplay
+                }
+
+                Spacer(minLength: 40)
+            }
+            .padding(.horizontal)
+            .padding(.top, 8)
+        }
+        .navigationTitle("WallpaperX")
+        .settingsToolbar(deviceVM: deviceVM, settings: settings)
+        .toolbar { toolbarActions }
+        .fileImporter(
+            isPresented: $wallpaperVM.showFileImporter,
+            allowedContentTypes: [.image],
+            allowsMultipleSelection: false
+        ) { handleFileImport($0) }
+        .sheet(isPresented: $wallpaperVM.showShareSheet) {
+            if let data = wallpaperVM.lastBMPData,
+               let filename = wallpaperVM.lastBMPFilename {
+                WallpaperShareSheetView(bmpData: data, filename: filename)
+            }
+        }
+    }
+    #endif
+
+    // MARK: - Preview Area (iOS)
+
+    private var previewArea: some View {
+        VStack(spacing: 12) {
+            Spacer(minLength: 4)
+            devicePreviewCard
+            imageSourceButtons
+                .padding(.horizontal)
+            Spacer(minLength: 4)
+        }
+    }
+
+    // MARK: - Device Preview Card
+
+    private var devicePreviewCard: some View {
+        VStack(spacing: 6) {
+            ZStack {
+                if let preview = wallpaperVM.processedPreview {
+                    Image(decorative: preview, scale: 1.0)
+                        .resizable()
+                        .interpolation(.high)
+                        .aspectRatio(
+                            wallpaperVM.device.aspectRatio,
+                            contentMode: .fit
+                        )
+                } else {
+                    Rectangle()
+                        .fill(.quaternary)
+                        .aspectRatio(
+                            wallpaperVM.device.aspectRatio,
+                            contentMode: .fit
+                        )
+                        .overlay {
+                            VStack(spacing: 12) {
+                                Image(systemName: "photo.artframe")
+                                    .font(.system(size: 36))
+                                    .foregroundStyle(.tertiary)
+                                Text("Select an image")
+                                    .font(.subheadline)
+                                    .foregroundStyle(.tertiary)
+                            }
+                        }
+                }
+            }
+            .clipShape(.rect(cornerRadius: 10))
+            .overlay {
+                RoundedRectangle(cornerRadius: 10)
+                    .strokeBorder(.tertiary.opacity(0.5), lineWidth: 0.5)
+            }
+            .shadow(color: .black.opacity(0.15), radius: 8, y: 4)
+            .padding(.horizontal)
+
+            HStack(spacing: 4) {
+                Image(systemName: "display")
+                    .font(.caption2)
+                Text(wallpaperVM.device.name)
+                    .font(.caption2.weight(.medium))
+                Text(
+                    "\(Int(wallpaperVM.device.resolution.width))\u{00D7}\(Int(wallpaperVM.device.resolution.height))"
+                )
+                .font(.caption2.monospacedDigit())
+            }
+            .foregroundStyle(.secondary)
+        }
+    }
+
+    // MARK: - Image Source Buttons
+
+    private var imageSourceButtons: some View {
+        HStack(spacing: 10) {
+            PhotosPicker(
+                selection: $wallpaperVM.selectedPhotoItem,
+                matching: .images,
+                photoLibrary: .shared()
+            ) {
+                Label("Photos", systemImage: "photo.on.rectangle")
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+            }
+            .buttonStyle(.bordered)
+            .buttonBorderShape(.roundedRectangle(radius: 10))
+
+            Button {
+                wallpaperVM.showFileImporter = true
+            } label: {
+                Label("Files", systemImage: "folder")
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 10)
+            }
+            .buttonStyle(.bordered)
+            .buttonBorderShape(.roundedRectangle(radius: 10))
+
+            if wallpaperVM.sourceImage != nil {
+                Button(role: .destructive) {
+                    wallpaperVM.clearImage()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.title3)
+                }
+                .buttonStyle(.borderless)
+            }
+        }
+    }
+
+    // MARK: - Settings Controls (shared between macOS inline & iOS sheet)
+
+    var settingsControls: some View {
+        VStack(spacing: 20) {
+            // Fit Mode
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Fit")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .textCase(.uppercase)
+
+                Picker("Fit Mode", selection: $wallpaperVM.settings.fitMode) {
+                    ForEach(WallpaperFitMode.allCases, id: \.self) { mode in
+                        Image(systemName: mode.iconName).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+
+            // Alignment
+            if wallpaperVM.settings.fitMode != .stretch {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Alignment")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .textCase(.uppercase)
+
+                    alignmentGrid
+                }
+            }
+
+            Divider()
+
+            // Rotation
+            HStack {
+                Text("Rotate")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .textCase(.uppercase)
+
+                Spacer()
+
+                rotationControls
+            }
+
+            Divider()
+
+            // Color Depth
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Depth")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .textCase(.uppercase)
+
+                Picker("Depth", selection: $wallpaperVM.settings.colorDepth) {
+                    ForEach(BMPColorDepth.allCases, id: \.self) { depth in
+                        Text(depth.label).tag(depth)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                if let warning = wallpaperVM.settings.colorDepth.warningText {
+                    Label(warning, systemImage: "exclamationmark.triangle.fill")
+                        .font(.caption2)
+                        .foregroundStyle(AppColor.warning)
+                }
+            }
+
+            Divider()
+
+            // Effects
+            Toggle("Grayscale", isOn: $wallpaperVM.settings.grayscale)
+                .font(.subheadline)
+
+            Toggle("Invert", isOn: $wallpaperVM.settings.invert)
+                .font(.subheadline)
+        }
+    }
+
+    // MARK: - Alignment Grid
+
+    private var alignmentGrid: some View {
+        HStack {
+            Spacer()
+            Grid(horizontalSpacing: 4, verticalSpacing: 4) {
+                ForEach(0..<3) { row in
+                    GridRow {
+                        ForEach(0..<3) { col in
+                            let alignment = alignmentFor(column: col, row: row)
+                            let isSelected =
+                                wallpaperVM.settings.alignment == alignment
+                            Button {
+                                wallpaperVM.settings.alignment = alignment
+                            } label: {
+                                RoundedRectangle(cornerRadius: 3)
+                                    .fill(
+                                        isSelected
+                                            ? AnyShapeStyle(AppColor.accent)
+                                            : AnyShapeStyle(.quaternary)
+                                    )
+                                    .frame(width: 28, height: 28)
+                                    .overlay {
+                                        Circle()
+                                            .fill(
+                                                isSelected
+                                                    ? AnyShapeStyle(.white)
+                                                    : AnyShapeStyle(
+                                                        .secondary)
+                                            )
+                                            .frame(width: 6, height: 6)
+                                    }
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+            }
+            Spacer()
+        }
+    }
+
+    private func alignmentFor(column: Int, row: Int) -> WallpaperAlignment {
+        let all: [[WallpaperAlignment]] = [
+            [.topLeft, .topCenter, .topRight],
+            [.centerLeft, .centerCenter, .centerRight],
+            [.bottomLeft, .bottomCenter, .bottomRight],
+        ]
+        return all[row][column]
+    }
+
+    // MARK: - Rotation Controls
+
+    private var rotationControls: some View {
+        HStack(spacing: 10) {
+            Button {
+                wallpaperVM.settings.rotation =
+                    wallpaperVM.settings.rotation.rotatedCounterClockwise
+            } label: {
+                Image(systemName: "rotate.left")
+            }
+            .buttonStyle(.bordered)
+            .buttonBorderShape(.circle)
+            .controlSize(.small)
+
+            Text("\(wallpaperVM.settings.rotation.rawValue)\u{00B0}")
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(.tertiary)
+                .frame(minWidth: 28)
+
+            Button {
+                wallpaperVM.settings.rotation =
+                    wallpaperVM.settings.rotation.rotatedClockwise
+            } label: {
+                Image(systemName: "rotate.right")
+            }
+            .buttonStyle(.bordered)
+            .buttonBorderShape(.circle)
+            .controlSize(.small)
+        }
+    }
+
+    // MARK: - iOS Toolbar
+
+    #if os(iOS)
+    @ToolbarContentBuilder
+    private var wallpaperToolbar: some ToolbarContent {
+        ToolbarItemGroup(placement: .topBarLeading) {
+            // Device connection status
+            Button {
+                showDevicePopover = true
+            } label: {
+                HStack(spacing: 5) {
+                    Circle()
+                        .fill(deviceStatusColor)
+                        .frame(width: 7, height: 7)
+                    Text(
+                        deviceVM.isConnected
+                            ? "Connected" : "Not Connected"
+                    )
+                    .font(.caption2)
+                }
+            }
+            .popover(isPresented: $showDevicePopover) {
+                devicePopoverContent
+            }
+
+            // Gear (app settings)
+            Button {
+                showAppSettings = true
+            } label: {
+                Image(systemName: "gearshape")
+            }
+        }
+
+        ToolbarItemGroup(placement: .topBarTrailing) {
+            if wallpaperVM.lastBMPData != nil {
+                Button {
+                    wallpaperVM.showShareSheet = true
+                } label: {
+                    Label("Save", systemImage: "square.and.arrow.up")
+                }
+            }
+
+            Button {
+                Task {
+                    await wallpaperVM.convertAndSend(
+                        deviceVM: deviceVM,
+                        settings: settings,
+                        modelContext: modelContext
+                    )
+                }
+            } label: {
+                if wallpaperVM.isProcessing {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Label(
+                        deviceVM.isConnected ? "Send" : "Convert",
+                        systemImage: deviceVM.isConnected
+                            ? "paperplane.fill" : "photo.artframe"
+                    )
+                }
+            }
+            .disabled(
+                wallpaperVM.sourceImage == nil || wallpaperVM.isProcessing
+                    || deviceVM.isUploading)
+        }
+    }
+    #endif
+
+    // MARK: - Device Popover
+
+    private var devicePopoverContent: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(deviceStatusColor)
+                    .frame(width: 10, height: 10)
+                Text(deviceVM.firmwareLabel)
+                    .font(.subheadline.weight(.semibold))
+            }
+
+            if deviceVM.isConnected, let host = deviceVM.connectedHost {
+                Label(host, systemImage: "network")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Divider()
+
+            HStack(spacing: 12) {
+                Button {
+                    Task { await deviceVM.refresh(settings: settings) }
+                } label: {
+                    Label("Refresh", systemImage: "arrow.clockwise")
+                        .font(.subheadline)
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+
+                Button {
+                    if deviceVM.isConnected {
+                        deviceVM.disconnect()
+                    } else {
+                        Task { await deviceVM.search(settings: settings) }
+                    }
+                } label: {
+                    Text(
+                        deviceVM.isConnected ? "Disconnect" : "Connect"
+                    )
+                    .font(.subheadline)
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .tint(
+                    deviceVM.isConnected ? .secondary : .accentColor)
+            }
+
+            if deviceVM.isSearching {
+                HStack(spacing: 6) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text("Scanning...")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .padding()
+        .frame(minWidth: 220)
+    }
+
+    // MARK: - macOS Toolbar
+
+    #if os(macOS)
+    @ToolbarContentBuilder
+    private var toolbarActions: some ToolbarContent {
+        ToolbarItemGroup(placement: .primaryAction) {
+            if wallpaperVM.lastBMPData != nil {
+                Button {
+                    wallpaperVM.showShareSheet = true
+                } label: {
+                    Label("Save", systemImage: "square.and.arrow.up")
+                }
+            }
+
+            Button {
+                Task {
+                    await wallpaperVM.convertAndSend(
+                        deviceVM: deviceVM,
+                        settings: settings,
+                        modelContext: modelContext
+                    )
+                }
+            } label: {
+                if wallpaperVM.isProcessing {
+                    ProgressView()
+                        .controlSize(.small)
+                } else {
+                    Label(
+                        deviceVM.isConnected ? "Send" : "Convert",
+                        systemImage: deviceVM.isConnected
+                            ? "paperplane.fill" : "photo.artframe"
+                    )
+                }
+            }
+            .disabled(
+                wallpaperVM.sourceImage == nil || wallpaperVM.isProcessing
+                    || deviceVM.isUploading)
+        }
+    }
+    #endif
+
+    // MARK: - Status Bar (iOS)
+
+    @ViewBuilder
+    private var statusBar: some View {
+        if let error = wallpaperVM.errorMessage {
+            HStack(spacing: 6) {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(AppColor.error)
+                    .font(.caption)
+                Text(error)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 6)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else if let status = wallpaperVM.statusMessage,
+            !wallpaperVM.isProcessing
+        {
+            HStack(spacing: 6) {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(AppColor.success)
+                    .font(.caption)
+                Text(status)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(1)
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 6)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else if wallpaperVM.isProcessing {
+            HStack(spacing: 6) {
+                ProgressView()
+                    .controlSize(.mini)
+                Text(wallpaperVM.statusMessage ?? "Processing...")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 6)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    // MARK: - Status Display (macOS)
+
+    @ViewBuilder
+    private var statusDisplay: some View {
+        if let error = wallpaperVM.errorMessage {
+            HStack {
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(AppColor.error)
+                Text(error)
+                    .foregroundStyle(.secondary)
+                    .font(.footnote)
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .glassEffect(.regular, in: .rect(cornerRadius: 12))
+        } else if let status = wallpaperVM.statusMessage,
+            !wallpaperVM.isProcessing
+        {
+            HStack {
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(AppColor.success)
+                Text(status)
+                    .foregroundStyle(.secondary)
+                    .font(.footnote)
+            }
+            .padding()
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .glassEffect(.regular, in: .rect(cornerRadius: 12))
+        }
+    }
+
+    // MARK: - Helpers
+
+    private var deviceStatusColor: Color {
+        if deviceVM.isSearching { return AppColor.warning }
+        return deviceVM.isConnected ? AppColor.success : AppColor.error
+    }
+
+    private func handleFileImport(_ result: Result<[URL], Error>) {
+        switch result {
+        case .success(let urls):
+            if let url = urls.first {
+                wallpaperVM.loadImage(from: url)
+            }
+        case .failure(let error):
+            wallpaperVM.errorMessage = error.localizedDescription
         }
     }
 }
+
+// MARK: - WallpaperQuickControls (tab bar bottom accessory)
+
+/// Minimal controls shown in the tab bar bottom accessory when WallpaperX is selected.
+/// Contains rotation buttons, an "Advanced" button, and a global upload progress indicator.
+struct WallpaperQuickControls: View {
+    @Bindable var wallpaperVM: WallpaperViewModel
+    var deviceVM: DeviceViewModel
+    @Binding var showAdvancedSettings: Bool
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Upload progress bar — thin line across full width (matches DeviceConnectionAccessory)
+            if deviceVM.isUploading {
+                ProgressView(value: deviceVM.uploadProgress, total: 1.0)
+                    .tint(.accentColor)
+                    .scaleEffect(y: 0.5)
+            }
+
+            HStack(spacing: 16) {
+                // Rotate CCW
+                Button {
+                    wallpaperVM.settings.rotation =
+                        wallpaperVM.settings.rotation.rotatedCounterClockwise
+                } label: {
+                    Image(systemName: "rotate.left")
+                        .font(.body)
+                }
+                .buttonStyle(.bordered)
+                .buttonBorderShape(.circle)
+                .controlSize(.small)
+
+                // Rotation label
+                Text("\(wallpaperVM.settings.rotation.rawValue)\u{00B0}")
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.secondary)
+                    .frame(minWidth: 28)
+
+                // Rotate CW
+                Button {
+                    wallpaperVM.settings.rotation =
+                        wallpaperVM.settings.rotation.rotatedClockwise
+                } label: {
+                    Image(systemName: "rotate.right")
+                        .font(.body)
+                }
+                .buttonStyle(.bordered)
+                .buttonBorderShape(.circle)
+                .controlSize(.small)
+
+                Spacer()
+
+                if deviceVM.isUploading {
+                    // Show upload progress instead of Advanced button
+                    HStack(spacing: 6) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("\(Int(deviceVM.uploadProgress * 100))%")
+                            .font(.caption.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                    }
+                } else {
+                    // Advanced settings button
+                    Button {
+                        showAdvancedSettings = true
+                    } label: {
+                        Label("Advanced", systemImage: "slider.horizontal.3")
+                            .font(.subheadline.weight(.medium))
+                    }
+                    .buttonStyle(.bordered)
+                    .buttonBorderShape(.capsule)
+                    .controlSize(.small)
+                    .tint(.accentColor)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 8)
+        }
+    }
+}
+
+// MARK: - WallpaperAdvancedSheet
+
+/// Full settings sheet presented with system detents for smooth 120fps interaction.
+#if os(iOS)
+struct WallpaperAdvancedSheet: View {
+    @Environment(\.dismiss) private var dismiss
+    @Bindable var wallpaperVM: WallpaperViewModel
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                // Reuse the shared settings controls from WallpaperXView
+                WallpaperXView.settingsControlsContent(wallpaperVM: wallpaperVM)
+                    .padding(.horizontal, 20)
+                    .padding(.top, 8)
+                    .padding(.bottom, 24)
+            }
+            .scrollBounceBehavior(.basedOnSize)
+            .navigationTitle("Settings")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button("Done") {
+                        dismiss()
+                    }
+                    .fontWeight(.semibold)
+                }
+            }
+        }
+        .presentationDetents([.fraction(0.45), .medium, .large])
+        .presentationDragIndicator(.visible)
+        .presentationBackgroundInteraction(.enabled(upThrough: .medium))
+    }
+}
+#endif
+
+// MARK: - Static settings helper (for sheet reuse)
+
+extension WallpaperXView {
+    /// Extracted settings controls as a static function so the sheet can reuse them
+    /// without needing a full WallpaperXView instance.
+    static func settingsControlsContent(wallpaperVM: WallpaperViewModel)
+        -> some View
+    {
+        _SettingsControlsContent(wallpaperVM: wallpaperVM)
+    }
+}
+
+/// Internal view wrapping the settings controls for reuse.
+private struct _SettingsControlsContent: View {
+    @Bindable var wallpaperVM: WallpaperViewModel
+
+    var body: some View {
+        VStack(spacing: 20) {
+            // Fit Mode
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Fit")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .textCase(.uppercase)
+
+                Picker("Fit Mode", selection: $wallpaperVM.settings.fitMode) {
+                    ForEach(WallpaperFitMode.allCases, id: \.self) { mode in
+                        Image(systemName: mode.iconName).tag(mode)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+
+            // Alignment
+            if wallpaperVM.settings.fitMode != .stretch {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Alignment")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .textCase(.uppercase)
+
+                    alignmentGrid
+                }
+            }
+
+            Divider()
+
+            // Rotation
+            HStack {
+                Text("Rotate")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .textCase(.uppercase)
+
+                Spacer()
+
+                rotationControls
+            }
+
+            Divider()
+
+            // Color Depth
+            VStack(alignment: .leading, spacing: 8) {
+                Text("Depth")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .textCase(.uppercase)
+
+                Picker(
+                    "Depth", selection: $wallpaperVM.settings.colorDepth
+                ) {
+                    ForEach(BMPColorDepth.allCases, id: \.self) { depth in
+                        Text(depth.label).tag(depth)
+                    }
+                }
+                .pickerStyle(.segmented)
+
+                if let warning = wallpaperVM.settings.colorDepth.warningText
+                {
+                    Label(
+                        warning,
+                        systemImage: "exclamationmark.triangle.fill"
+                    )
+                    .font(.caption2)
+                    .foregroundStyle(AppColor.warning)
+                }
+            }
+
+            Divider()
+
+            // Effects
+            Toggle("Grayscale", isOn: $wallpaperVM.settings.grayscale)
+                .font(.subheadline)
+
+            Toggle("Invert", isOn: $wallpaperVM.settings.invert)
+                .font(.subheadline)
+        }
+    }
+
+    // MARK: - Alignment Grid
+
+    private var alignmentGrid: some View {
+        HStack {
+            Spacer()
+            Grid(horizontalSpacing: 4, verticalSpacing: 4) {
+                ForEach(0..<3) { row in
+                    GridRow {
+                        ForEach(0..<3) { col in
+                            let alignment = alignmentFor(
+                                column: col, row: row)
+                            let isSelected =
+                                wallpaperVM.settings.alignment == alignment
+                            Button {
+                                wallpaperVM.settings.alignment = alignment
+                            } label: {
+                                RoundedRectangle(cornerRadius: 3)
+                                    .fill(
+                                        isSelected
+                                            ? AnyShapeStyle(AppColor.accent)
+                                            : AnyShapeStyle(.quaternary)
+                                    )
+                                    .frame(width: 28, height: 28)
+                                    .overlay {
+                                        Circle()
+                                            .fill(
+                                                isSelected
+                                                    ? AnyShapeStyle(.white)
+                                                    : AnyShapeStyle(
+                                                        .secondary)
+                                            )
+                                            .frame(width: 6, height: 6)
+                                    }
+                            }
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
+            }
+            Spacer()
+        }
+    }
+
+    private func alignmentFor(column: Int, row: Int) -> WallpaperAlignment {
+        let all: [[WallpaperAlignment]] = [
+            [.topLeft, .topCenter, .topRight],
+            [.centerLeft, .centerCenter, .centerRight],
+            [.bottomLeft, .bottomCenter, .bottomRight],
+        ]
+        return all[row][column]
+    }
+
+    // MARK: - Rotation Controls
+
+    private var rotationControls: some View {
+        HStack(spacing: 10) {
+            Button {
+                wallpaperVM.settings.rotation =
+                    wallpaperVM.settings.rotation.rotatedCounterClockwise
+            } label: {
+                Image(systemName: "rotate.left")
+            }
+            .buttonStyle(.bordered)
+            .buttonBorderShape(.circle)
+            .controlSize(.small)
+
+            Text("\(wallpaperVM.settings.rotation.rawValue)\u{00B0}")
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(.tertiary)
+                .frame(minWidth: 28)
+
+            Button {
+                wallpaperVM.settings.rotation =
+                    wallpaperVM.settings.rotation.rotatedClockwise
+            } label: {
+                Image(systemName: "rotate.right")
+            }
+            .buttonStyle(.bordered)
+            .buttonBorderShape(.circle)
+            .controlSize(.small)
+        }
+    }
+}
+
+// MARK: - Share Sheet (Platform-Adaptive)
+
+#if canImport(UIKit)
+import UIKit
+
+struct WallpaperShareSheetView: UIViewControllerRepresentable {
+    let bmpData: Data
+    let filename: String
+
+    func makeUIViewController(context: Context)
+        -> UIActivityViewController
+    {
+        let tempURL =
+            FileManager.default.temporaryDirectory
+            .appendingPathComponent(filename)
+        try? bmpData.write(to: tempURL)
+
+        return UIActivityViewController(
+            activityItems: [tempURL],
+            applicationActivities: nil
+        )
+    }
+
+    func updateUIViewController(
+        _ uiViewController: UIActivityViewController,
+        context: Context
+    ) {}
+}
+
+#elseif canImport(AppKit)
+import AppKit
+
+struct WallpaperShareSheetView: NSViewRepresentable {
+    let bmpData: Data
+    let filename: String
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        DispatchQueue.main.async {
+            let tempURL =
+                FileManager.default.temporaryDirectory
+                .appendingPathComponent(filename)
+            try? bmpData.write(to: tempURL)
+
+            let picker = NSSharingServicePicker(items: [tempURL])
+            picker.show(
+                relativeTo: view.bounds, of: view, preferredEdge: .minY)
+        }
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {}
+}
+#endif


### PR DESCRIPTION
Implement full WallpaperX feature for converting images to BMP format for the X4 e-reader (480x800). Includes BMP encoder (24/8/4/1-bit), Core Graphics image processor with fit/fill/stretch modes, 9-point alignment, rotation, grayscale, and inversion.

UI uses tabViewBottomAccessory for quick controls and system sheet with presentation detents for advanced settings (smooth 120fps).

Also fixes alignment Y-axis inversion (CG bottom-left origin), adds timestamped filenames to prevent overwrites, and introduces global upload progress tracking on DeviceViewModel visible across all tabs with concurrent upload prevention.

## Summary

<!-- Describe your changes in 2-3 bullet points -->

-
-
-

## Change Type

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation
- [ ] Build / configuration

## Scope

<!-- Check all areas touched by this PR -->

- [ ] Views
- [ ] ViewModels
- [ ] Services
- [ ] Models
- [ ] Utilities
- [ ] Share Extension
- [ ] Build / project config

## Linked Issue

<!-- Reference related issues. Use "Closes #123" to auto-close on merge -->

- Closes #
- Related #

## How It Was Tested

<!-- Describe what you tested and how -->

- [ ] Builds on iOS (`xcodebuild ... -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`)
- [ ] Builds on macOS (`xcodebuild ... -destination 'platform=macOS'`)
- [ ] Tested manually on simulator / device
- [ ] N/A (docs or config only)

**Test details:**

<!-- Describe the scenarios you tested, edge cases checked, etc. -->

## Screenshots

<!-- Optional: attach screenshots or recordings for UI changes -->

## Checklist

<!-- Confirm before requesting review -->

- [ ] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] No force unwraps (`!`) added
- [ ] iOS-only modifiers wrapped in `#if os(iOS)`
- [ ] New service types are marked `nonisolated`
- [ ] ViewModels go through service protocols (no direct service calls from Views)
