### PR TITLE
Make RSS feed folder name configurable

### DIFF
--- a/SendToX4/Models/DeviceSettings.swift
+++ b/SendToX4/Models/DeviceSettings.swift
@@ -61,6 +61,12 @@ final class DeviceSettings {
     /// Destination folder for WallpaperX (wallpapers). Default: "sleep".
     var wallpaperFolder: String
 
+    /// Destination root folder for RSS feed articles. Default: "feed".
+    /// Articles are organized into per-domain subfolders: `<feedFolder>/<domain>/`.
+    /// Renaming this (e.g. to "aaa-feed") lets users surface it at the top of
+    /// the device's Files list.
+    var feedFolder: String = "feed"
+
     // MARK: - Language
 
     /// BCP-47 language code, or empty string for system default.
@@ -90,6 +96,7 @@ final class DeviceSettings {
         customIP: String = "",
         convertFolder: String = "content",
         wallpaperFolder: String = "sleep",
+        feedFolder: String = "feed",
         showFileManager: Bool = false,
         languageCode: String = ""
     ) {
@@ -97,6 +104,7 @@ final class DeviceSettings {
         self.customIP = customIP
         self.convertFolder = convertFolder
         self.wallpaperFolder = wallpaperFolder
+        self.feedFolder = feedFolder
         self.showFileManager = showFileManager
         self.languageCode = languageCode
     }

--- a/SendToX4/Utilities/Strings.swift
+++ b/SendToX4/Utilities/Strings.swift
@@ -135,6 +135,7 @@ enum L10n {
         case featureFolders
         case convertSectionLabel
         case wallpaperXSectionLabel
+        case rssFeedSectionLabel
         case featureFoldersDescription
         case testConnection
         case connectedWithInfo
@@ -604,7 +605,8 @@ enum L10n {
         .featureFolders: "Feature Folders",
         .convertSectionLabel: "Convert",
         .wallpaperXSectionLabel: "WallpaperX",
-        .featureFoldersDescription: "Each feature uploads to its own folder on the device (e.g. /%@/). Tap a field to change the destination.",
+        .rssFeedSectionLabel: "RSS Feed",
+        .featureFoldersDescription: "Each feature uploads to its own folder on the device (e.g. /%@/). Tap a field to change the destination. Tip: prefix with letters like \"aaa-\" to surface a folder at the top of Files.",
         .testConnection: "Test Connection",
         .connectedWithInfo: "Connected (%@)",
         .notReachable: "Not reachable",
@@ -1066,7 +1068,8 @@ enum L10n {
         .featureFolders: "功能文件夹",
         .convertSectionLabel: "转换",
         .wallpaperXSectionLabel: "壁纸X",
-        .featureFoldersDescription: "每个功能上传到设备上各自的文件夹（例如 /%@/）。点击字段更改目标位置。",
+        .rssFeedSectionLabel: "RSS 订阅",
+        .featureFoldersDescription: "每个功能上传到设备上各自的文件夹（例如 /%@/）。点击字段更改目标位置。提示：用字母前缀（如 \"aaa-\"）可让文件夹排在「文件」列表顶部。",
         .testConnection: "测试连接",
         .connectedWithInfo: "已连接（%@）",
         .notReachable: "无法连接",

--- a/SendToX4/ViewModels/RSSFeedViewModel.swift
+++ b/SendToX4/ViewModels/RSSFeedViewModel.swift
@@ -313,8 +313,10 @@ final class RSSFeedViewModel {
                 modelContext.insert(newArticle)
                 article = newArticle
 
-                // Destination folder: /feed/<domain>/
-                let destFolder = "feed/\(rssArticle.domain)"
+                // Destination folder: /<feedFolder>/<domain>/
+                let feedRoot = settings.feedFolder.trimmingCharacters(in: CharacterSet(charactersIn: "/ "))
+                let safeFeedRoot = feedRoot.isEmpty ? "feed" : feedRoot
+                let destFolder = "\(safeFeedRoot)/\(rssArticle.domain)"
 
                 if deviceVM.isConnected && !deviceVM.isBatchDeleting {
                     // Send directly

--- a/SendToX4/Views/SettingsSheet.swift
+++ b/SendToX4/Views/SettingsSheet.swift
@@ -176,6 +176,21 @@ struct SettingsSheet: View {
                 }
             }
             .padding(.vertical, 2)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(loc(.rssFeedSectionLabel))
+                    .font(.subheadline.weight(.medium))
+                HStack {
+                    Image(systemName: "folder")
+                        .foregroundStyle(.secondary)
+                    TextField("feed", text: $settings.feedFolder)
+                        .autocorrectionDisabled()
+                        #if os(iOS)
+                        .textInputAutocapitalization(.never)
+                        #endif
+                }
+            }
+            .padding(.vertical, 2)
         } header: {
             Text(loc(.featureFolders))
         } footer: {


### PR DESCRIPTION
## Summary
- Adds a new "RSS Feed" entry in Settings → Feature Folders, alongside Convert and WallpaperX
- Adds a `feedFolder` property to `DeviceSettings` (default `"feed"`) so the value persists
- `RSSFeedViewModel` now uses `settings.feedFolder` (sanitized — strips slashes/whitespace, falls back to `"feed"` if empty) when computing the per-domain destination path
- Updated the section footer to hint that prefixes like `aaa-` will surface the folder at the top of the device's Files list (en + zh-Hans)

## Why
Today the RSS folder is hardcoded to `feed`, which sorts alphabetically in the middle of the device's Files list. Reaching a New Yorker article requires: Files → scroll to "feed" → tap `newyorker.com` → find the article. Letting users rename the folder (e.g. to `aaa-feed`) lets them surface it at the top so the path is much shorter.

## Notes for reviewers
- Existing `QueueItem`s store `destinationFolder` as a snapshot string, so already-queued items keep their old path — only new conversions pick up the renamed folder. That seemed like the right behavior (don't retroactively change where queued items will land).
- The sanitizer trims `/` and whitespace and falls back to `"feed"` on empty input, so the user can't accidentally write to the device root or break the path joiner.

## Test plan
- [ ] Open Settings → Feature Folders, confirm the new "RSS Feed" row appears with default `feed`
- [ ] Rename to `aaa-feed`, send an RSS article, verify it lands at `/aaa-feed/<domain>/`
- [ ] Clear the field — verify it falls back to `feed` rather than uploading to root
- [ ] Verify zh-Hans copy renders correctly