### PR TITLE
fix: HTTP RSS feeds, RSS feed data loss, and Xteink X3 wallpaper support

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -4,8 +4,10 @@
 <dict>
 	<key>NSAppTransportSecurity</key>
 	<dict>
-		<key>NSAllowsLocalNetworking</key>
-		<true/>
+		<!-- Covers local device networking too. Do NOT re-add
+		     NSAllowsLocalNetworking alongside it: when both are present,
+		     iOS 10+ ignores NSAllowsArbitraryLoads and HTTP RSS feeds
+		     stop loading again (issue #21). -->
 		<key>NSAllowsArbitraryLoads</key>
 		<true/>
 	</dict>

--- a/SendToX4.xcodeproj/project.pbxproj
+++ b/SendToX4.xcodeproj/project.pbxproj
@@ -14,6 +14,16 @@
 		CC00000ECCCCCCCC0000000E /* SwiftSoup in Frameworks */ = {isa = PBXBuildFile; productRef = CC00000CCCCCCCCC0000000C /* SwiftSoup */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		0636842A3002FB5B008ABC4C /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 062C179A2F4015F7007E89F9 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 062C17A12F4015F7007E89F9;
+			remoteInfo = SendToX4;
+		};
+/* End PBXContainerItemProxy section */
+
 /* Begin PBXFileReference section */
 		062C17A22F4015F7007E89F9 /* SendToX4.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SendToX4.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		CC000001CCCCCCCC00000001 /* SendToX4Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = SendToX4Tests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -208,6 +218,7 @@
 		CC00000ACCCCCCCC0000000A /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 062C17A12F4015F7007E89F9 /* SendToX4 */;
+			targetProxy = 0636842A3002FB5B008ABC4C /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 

--- a/SendToX4/Intents/ConvertURLIntent.swift
+++ b/SendToX4/Intents/ConvertURLIntent.swift
@@ -202,15 +202,11 @@ struct ConvertURLIntent: AppIntent {
     // MARK: - Private Helpers
 
     /// Create a ModelContext using the same SwiftData store as the main app.
+    /// Must use the full `AppSchema.schema`: opening the shared store with a
+    /// subset schema silently drops the omitted entities' data (issue #20).
     private static func makeModelContext() throws -> ModelContext {
-        let schema = Schema([
-            Article.self,
-            DeviceSettings.self,
-            ActivityEvent.self,
-            QueueItem.self,
-        ])
-        let config = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
-        let container = try ModelContainer(for: schema, configurations: [config])
+        let config = ModelConfiguration(schema: AppSchema.schema, isStoredInMemoryOnly: false)
+        let container = try ModelContainer(for: AppSchema.schema, configurations: [config])
         return ModelContext(container)
     }
 

--- a/SendToX4/Models/AppSchema.swift
+++ b/SendToX4/Models/AppSchema.swift
@@ -1,0 +1,20 @@
+import SwiftData
+
+/// Single source of truth for the app's SwiftData schema.
+///
+/// Every entry point that opens the shared on-disk store (the main app,
+/// App Intents, extensions) MUST build its container from this schema.
+/// Opening the store with a subset of the entities triggers an automatic
+/// migration that silently DROPS the omitted entities' data — this is
+/// exactly how saved RSS feeds were wiped whenever the Convert intent ran
+/// outside the app (issue #20).
+enum AppSchema {
+    static let schema = Schema([
+        Article.self,
+        DeviceSettings.self,
+        ActivityEvent.self,
+        QueueItem.self,
+        RSSFeed.self,
+        RSSArticle.self,
+    ])
+}

--- a/SendToX4/Models/DeviceSettings.swift
+++ b/SendToX4/Models/DeviceSettings.swift
@@ -73,11 +73,16 @@ final class DeviceSettings {
     /// Default: disabled (text-only EPUBs).
     var includeImages: Bool = false
 
+    // MARK: - WallpaperX
+
+    /// `DeviceSpecification.id` of the wallpaper target device. Default: X4.
+    var wallpaperDeviceRaw: String = DeviceSpecification.x4.id
+
     // MARK: - Language
 
     /// BCP-47 language code, or empty string for system default.
     var languageCode: String
-    
+
     var firmwareType: FirmwareType {
         get { FirmwareType(rawValue: firmwareTypeRaw) ?? .stock }
         set { firmwareTypeRaw = newValue.rawValue }
@@ -87,6 +92,12 @@ final class DeviceSettings {
     var appLanguage: AppLanguage {
         get { AppLanguage(rawValue: languageCode) ?? .system }
         set { languageCode = newValue.rawValue }
+    }
+
+    /// Typed accessor for the wallpaper target device.
+    var wallpaperDevice: DeviceSpecification {
+        get { DeviceSpecification.all.first { $0.id == wallpaperDeviceRaw } ?? .x4 }
+        set { wallpaperDeviceRaw = newValue.id }
     }
     
     /// The resolved host address based on firmware type and custom setting.
@@ -105,7 +116,8 @@ final class DeviceSettings {
         showFileManager: Bool = false,
         languageCode: String = "",
         optimizeEPUBUpload: Bool = true,
-        includeImages: Bool = false
+        includeImages: Bool = false,
+        wallpaperDevice: DeviceSpecification = .x4
     ) {
         self.firmwareTypeRaw = firmwareType.rawValue
         self.customIP = customIP
@@ -115,5 +127,6 @@ final class DeviceSettings {
         self.languageCode = languageCode
         self.optimizeEPUBUpload = optimizeEPUBUpload
         self.includeImages = includeImages
+        self.wallpaperDeviceRaw = wallpaperDevice.id
     }
 }

--- a/SendToX4/Models/DeviceSpecification.swift
+++ b/SendToX4/Models/DeviceSpecification.swift
@@ -31,13 +31,20 @@ extension DeviceSpecification: Hashable {
 
     // MARK: - Known Devices
 
-    /// Xtreink X4 e-reader (480 x 800 e-ink display).
+    /// Xteink X4 e-reader (480 x 800 e-ink display).
     static let x4 = DeviceSpecification(
         id: "x4",
-        name: "Xtreink X4",
+        name: "Xteink X4",
         resolution: CGSize(width: 480, height: 800)
     )
 
+    /// Xteink X3 e-reader (528 x 792 e-ink display).
+    static let x3 = DeviceSpecification(
+        id: "x3",
+        name: "Xteink X3",
+        resolution: CGSize(width: 528, height: 792)
+    )
+
     /// All known device profiles.
-    static let all: [DeviceSpecification] = [.x4]
+    static let all: [DeviceSpecification] = [.x4, .x3]
 }

--- a/SendToX4/SendToX4App.swift
+++ b/SendToX4/SendToX4App.swift
@@ -13,21 +13,13 @@ struct SendToX4App: App {
     @AppStorage("hasSeenOnboarding") private var hasSeenOnboarding = false
 
     var sharedModelContainer: ModelContainer = {
-        let schema = Schema([
-            Article.self,
-            DeviceSettings.self,
-            ActivityEvent.self,
-            QueueItem.self,
-            RSSFeed.self,
-            RSSArticle.self,
-        ])
         let modelConfiguration = ModelConfiguration(
-            schema: schema,
+            schema: AppSchema.schema,
             isStoredInMemoryOnly: false
         )
 
         do {
-            return try ModelContainer(for: schema, configurations: [modelConfiguration])
+            return try ModelContainer(for: AppSchema.schema, configurations: [modelConfiguration])
         } catch {
             fatalError("Could not create ModelContainer: \(error)")
         }

--- a/SendToX4/Views/WallpaperXView.swift
+++ b/SendToX4/Views/WallpaperXView.swift
@@ -17,7 +17,7 @@ struct WallpaperXView: View {
     @Environment(\.requestReview) private var requestReview
     @Bindable var wallpaperVM: WallpaperViewModel
     var deviceVM: DeviceViewModel
-    var settings: DeviceSettings
+    @Bindable var settings: DeviceSettings
     var toast: ToastManager
 
     @AppStorage("pinchToZoomEnabled") private var pinchToZoomEnabled = false
@@ -74,6 +74,13 @@ struct WallpaperXView: View {
                 ReviewPromptManager.recordPromptShown()
                 requestReview()
             }
+        }
+        .onAppear {
+            wallpaperVM.device = settings.wallpaperDevice
+        }
+        .onChange(of: settings.wallpaperDeviceRaw) { _, _ in
+            wallpaperVM.device = settings.wallpaperDevice
+            wallpaperVM.updatePreview()
         }
     }
 
@@ -567,6 +574,23 @@ struct WallpaperXView: View {
 
     var settingsControls: some View {
         VStack(spacing: 20) {
+            // Target Device
+            VStack(alignment: .leading, spacing: 8) {
+                Text(loc(.device))
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                    .textCase(.uppercase)
+
+                Picker(loc(.device), selection: $settings.wallpaperDevice) {
+                    ForEach(DeviceSpecification.all) { spec in
+                        Text(spec.name).tag(spec)
+                    }
+                }
+                .pickerStyle(.segmented)
+            }
+
+            Divider()
+
             // Fit Mode
             VStack(alignment: .leading, spacing: 8) {
                 Text(loc(.fit))

--- a/SendToX4/Views/WallpaperXView.swift
+++ b/SendToX4/Views/WallpaperXView.swift
@@ -824,6 +824,24 @@ struct WallpaperXView: View {
         }
 
         ToolbarItemGroup(placement: .topBarTrailing) {
+            // Target device (X4/X3) — kept in the header so it's always reachable
+            Menu {
+                Picker(loc(.device), selection: $settings.wallpaperDevice) {
+                    ForEach(DeviceSpecification.all) { spec in
+                        Text(
+                            "\(spec.name) (\(Int(spec.resolution.width))\u{00D7}\(Int(spec.resolution.height)))"
+                        )
+                        .tag(spec)
+                    }
+                }
+            } label: {
+                HStack(spacing: 3) {
+                    Image(systemName: "display")
+                    Text(settings.wallpaperDevice.id.uppercased())
+                        .font(.caption.weight(.medium))
+                }
+            }
+
             if wallpaperVM.lastBMPData != nil {
                 Button {
                     wallpaperVM.showShareSheet = true

--- a/SendToX4Tests/AppSchemaTests.swift
+++ b/SendToX4Tests/AppSchemaTests.swift
@@ -1,0 +1,20 @@
+import SwiftData
+import Testing
+@testable import SendToX4
+
+struct AppSchemaTests {
+
+    /// Regression guard for issue #20: the Convert intent once opened the
+    /// shared store with a subset schema, and SwiftData's auto-migration
+    /// dropped the omitted RSS tables — wiping every saved feed. Any code
+    /// path that opens the shared store must use `AppSchema.schema`, and
+    /// that schema must keep covering every persisted entity.
+    @Test func schemaContainsAllPersistedEntities() {
+        let entityNames = Set(AppSchema.schema.entities.map(\.name))
+        let expected: Set<String> = [
+            "Article", "DeviceSettings", "ActivityEvent",
+            "QueueItem", "RSSFeed", "RSSArticle",
+        ]
+        #expect(entityNames == expected)
+    }
+}

--- a/SendToX4Tests/DeviceSpecificationTests.swift
+++ b/SendToX4Tests/DeviceSpecificationTests.swift
@@ -1,0 +1,27 @@
+import CoreGraphics
+import Testing
+@testable import SendToX4
+
+struct DeviceSpecificationTests {
+
+    @Test func x3SpecMatchesPanel() {
+        #expect(DeviceSpecification.x3.resolution == CGSize(width: 528, height: 792))
+        #expect(DeviceSpecification.all.contains(.x3))
+        #expect(DeviceSpecification.all.contains(.x4))
+    }
+
+    @Test func wallpaperDeviceAccessorRoundTrips() {
+        let settings = DeviceSettings()
+        #expect(settings.wallpaperDevice == .x4)
+
+        settings.wallpaperDevice = .x3
+        #expect(settings.wallpaperDeviceRaw == "x3")
+        #expect(settings.wallpaperDevice == .x3)
+    }
+
+    @Test func unknownStoredDeviceFallsBackToX4() {
+        let settings = DeviceSettings()
+        settings.wallpaperDeviceRaw = "x99"
+        #expect(settings.wallpaperDevice == .x4)
+    }
+}


### PR DESCRIPTION
Fixes three issues in one branch, one commit each (plus a follow-up UX commit).

## #20 — RSS feeds disappearing (data loss)
**Root cause:** `ConvertURLIntent` opened the shared SwiftData store with a schema missing `RSSFeed`/`RSSArticle`. Whenever the Convert intent ran outside the app (Siri/Shortcuts/Spotlight), SwiftData auto-migrated the store to that reduced schema and **dropped the RSS tables**, silently deleting every saved feed — matching the intermittent, log-free disappearances reported.

**Fix:** the full 6-entity schema now lives in one place (`AppSchema.schema`) used by both the app container (`SendToX4App`) and the intent, so no code path can open the store with a subset again. A regression test (`AppSchemaTests`) asserts the schema covers every persisted entity.

Note: feeds already wiped on affected installs cannot be recovered — this prevents future wipes.

Closes #20

## #21 — Allow HTTP RSS feeds
**Root cause:** `NSAllowsArbitraryLoads` was added in e039fbe but never took effect. ATS ignores `NSAllowsArbitraryLoads` on iOS 10+ when `NSAllowsLocalNetworking` is also present, so public `http://` feeds remained blocked and surfaced as "Failed to fetch feed". (The app itself never rejected `http://` URLs — no code change needed.)

**Fix:** removed `NSAllowsLocalNetworking` from `Info.plist`; `NSAllowsArbitraryLoads` alone also permits the local-network device connection. Verified the built product's ATS dict now contains only `NSAllowsArbitraryLoads`.

Closes #21

## #18 — Xteink X3 wallpaper support
Added the X3 device spec (**528×792**) and a target-device picker, persisted in `DeviceSettings.wallpaperDeviceRaw` (defaults to X4 so existing stores migrate untouched). The picker lives in two places:
- **WallpaperX header** (navigation bar): compact menu showing the current device (display icon + "X4"/"X3"), one tap away at all times
- WallpaperX settings controls: segmented X4/X3 picker

The wallpaper pipeline (fit/fill/stretch, pinch-to-zoom crop, BMP encoding, preview aspect) derives all geometry from `device.resolution`, so X3 flows through with no pipeline changes. Also fixes the "Xtreink" → "Xteink" typo in the device name.

Closes #18

## Test plan
- `xcodebuild build` for `generic/platform=iOS` → BUILD SUCCEEDED
- Full suite + new `AppSchemaTests` and `DeviceSpecificationTests` on iPhone 17 (iOS 26.2) simulator → all passed
- Built-product `Info.plist` ATS dict verified via `plutil`
- Manual: add an `http://` feed; run the Convert Shortcut then relaunch (feeds persist); switch header picker to X3 and confirm 528×792 output