### PR TITLE
chore: bump version to 2.7

### DIFF
--- a/SendToX4.xcodeproj/project.pbxproj
+++ b/SendToX4.xcodeproj/project.pbxproj
@@ -372,7 +372,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.2;
-				MARKETING_VERSION = 2.6;
+				MARKETING_VERSION = 2.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.crossappjtv.point;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;
@@ -423,7 +423,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "@executable_path/Frameworks";
 				"LD_RUNPATH_SEARCH_PATHS[sdk=macosx*]" = "@executable_path/../Frameworks";
 				MACOSX_DEPLOYMENT_TARGET = 26.2;
-				MARKETING_VERSION = 2.6;
+				MARKETING_VERSION = 2.7;
 				PRODUCT_BUNDLE_IDENTIFIER = com.crossappjtv.point;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;


### PR DESCRIPTION
Prepares the next App Store release: `MARKETING_VERSION` 2.6 → **2.7** (app target, Debug + Release), build number stays at 1.

## What ships in 2.7
- **In-app EPUB reader + Library tab** — read converted articles right in the app; converted EPUBs persist in a local library (#22)
- **Optional image support in converted EPUBs** (off by default)
- **EPUB optimizer** before device uploads (downscale/grayscale/JPEG, CrossPoint parity)
- **Xteink X3 wallpaper support** — 528×792 target-device picker in the WallpaperX header (#18)
- **HTTP RSS feeds** now load (ATS fix) (#21)
- **Fixed RSS feeds being wiped** when the Convert Shortcut/Siri intent ran (#20)
- New crossX app icon + designer credit (#23)
- Pipeline reliability fixes and expanded test coverage